### PR TITLE
Explain safety for `vec.set_len(0)`

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -816,6 +816,9 @@ impl<T> Vec<T> {
     /// let mut vec = vec![vec![1, 0, 0],
     ///                    vec![0, 1, 0],
     ///                    vec![0, 0, 1]];
+    /// // SAFETY:
+    /// // 1. `old_len..0` is empty so no elements need to be initialized.
+    /// // 2. `0 <= capacity` always holds whatever `capacity` is.
     /// unsafe {
     ///     vec.set_len(0);
     /// }


### PR DESCRIPTION
Couldn't leave a suggestion cause GitHub wouldn't let me... so I made a PR instead. :)